### PR TITLE
[ETFE-2338] added extra logs to confirmation screen for visualisations

### DIFF
--- a/app/controllers/ConfirmationController.scala
+++ b/app/controllers/ConfirmationController.scala
@@ -43,7 +43,8 @@ class ConfirmationController @Inject()(
   def onPageLoad(ern: String, arc: String): Action[AnyContent] =
     authorisedDataRequestWithCachedMovementAsync(ern, arc) { implicit request =>
       withAnswer(ConfirmationPage) { confirmationDetails =>
-        logger.info("[onPageLoad] Successful Explain Delay confirmation page displayed")
+        logger.info(s"[onPageLoad] Delay type: [${messagesApi(s"delayType.${confirmationDetails.delayType.toString}")(request.lang(messagesApi))}]")
+        logger.info(s"[onPageLoad] Delay reason: [${messagesApi(s"delayReason.${confirmationDetails.delayReason.toString}")(request.lang(messagesApi))}]")
         Future.successful(Ok(view(confirmationDetails)))
       }
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -127,6 +127,18 @@ auditing {
   enabled = true
 }
 
+controllers {
+  uk.gov.hmrc.govukfrontend.controllers.Assets {
+    needsLogging = false
+  }
+  uk.gov.hmrc.hmrcfrontend.controllers.Assets {
+    needsLogging = false
+  }
+  controllers.Assets {
+    needsLogging = false
+  }
+}
+
 accessibility-statement{
   service-path = "/emcs-tfe-explain-delay-frontend"
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -4,19 +4,19 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/emcs-tfe-explain-delay-frontend.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %date{ISO8601} %replace(%message){'(.*) (\d{3}) (\d*ms)','$2 $1 $3'} %replace(exception=[%xException]){'^exception=\[\]$',''} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %date{ISO8601} %replace(%message){'(.*) (\d{3}) (\d*ms)','$2 $1 $3'} %replace(exception=[%xException]){'^exception=\[\]$',''} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] %date{ISO8601} %replace(%message){'(.*) (\d{3}) (\d*ms)','$2 $1 $3'} %replace(exception=[%xException]){'^exception=\[\]$',''} %n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Capturing logs like below to aid in new monitoring visualisations.

![screenshot of console containing delay type and delay reason logs](https://github.com/hmrc/emcs-tfe-explain-delay-frontend/assets/31282758/7e9d079f-cddb-42cd-82b5-a8f1ffe1781c)
